### PR TITLE
Fix tests for new allauth release

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -62,3 +62,6 @@ REST_FRAMEWORK = {
 REST_AUTH = {
     "USE_JWT": True,
 }
+
+# Disable email verification to avoid unnecessary confirmation flow in tests
+ACCOUNT_EMAIL_VERIFICATION = "none"

--- a/vipps_auth/__init__.py
+++ b/vipps_auth/__init__.py
@@ -1,0 +1,39 @@
+"""Vipps Auth package initialization."""
+
+def patch_allauth_client() -> None:
+    """Monkey patch ``django-allauth``'s ``OAuth2Client`` for older callers."""
+
+    from allauth.socialaccount.providers.oauth2 import client as oauth2_client
+
+    class _CompatOAuth2Client(oauth2_client.OAuth2Client):
+        """Compatibility wrapper for ``OAuth2Client`` with a ``scope`` arg."""
+
+        def __init__(
+            self,
+            request,
+            consumer_key,
+            consumer_secret,
+            access_token_method,
+            access_token_url,
+            callback_url,
+            scope=None,
+            *,
+            scope_delimiter=" ",
+            headers=None,
+            basic_auth=False,
+        ) -> None:
+            # ``scope`` is ignored but retained for backward compatibility.
+            super().__init__(
+                request,
+                consumer_key,
+                consumer_secret,
+                access_token_method,
+                access_token_url,
+                callback_url,
+                scope_delimiter=scope_delimiter,
+                headers=headers,
+                basic_auth=basic_auth,
+            )
+
+    oauth2_client.OAuth2Client = _CompatOAuth2Client
+

--- a/vipps_auth/apps.py
+++ b/vipps_auth/apps.py
@@ -16,7 +16,11 @@ class VippsAuthConfig(AppConfig):
         try:
             from allauth.socialaccount import providers
             from .provider import VippsProvider
-            
+            # Apply compatibility monkey patch for OAuth2Client when the app is
+            # fully loaded and Django's registry is ready.
+            from . import patch_allauth_client
+
+            patch_allauth_client()
             providers.registry.register(VippsProvider)
         except ImportError:
             # This try/except block is a safeguard for cases where allauth

--- a/vipps_auth/views.py
+++ b/vipps_auth/views.py
@@ -17,6 +17,22 @@ class VippsOAuth2Adapter(OAuth2Adapter):
     authorize_url = VippsProvider.authorize_url
     profile_url = VippsProvider.profile_url
 
+    def complete_login(self, request, app, token, **kwargs):
+        """Fetch user info from Vipps and return a populated SocialLogin."""
+        import requests
+        from allauth.socialaccount import providers
+
+        headers = {
+            "Authorization": f"Bearer {token.token}",
+        }
+
+        resp = requests.get(self.profile_url, headers=headers)
+        resp.raise_for_status()
+        extra_data = resp.json()
+        provider_cls = providers.registry.get_class(self.provider_id)
+        provider = provider_cls(request, app=app)
+        return provider.sociallogin_from_response(request, extra_data)
+
 
 # These standard views use our adapter and provider correctly.
 vipps_login = OAuth2LoginView.adapter_view(VippsOAuth2Adapter)


### PR DESCRIPTION
## Summary
- patch django-allauth OAuth2Client for backwards compatibility
- register patch when app is ready
- implement Vipps adapter login flow
- disable email verification in tests

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685e8220c6b8832f81ea93be3e23f0a3